### PR TITLE
0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,17 @@ python demo_cli.py \
     --snapshots firefox chrome ie \
     --vboxmanage /usr/bin/vboxmanage \
     --timeout 60 \
-    --info 1 \
     --threads 2 \
     --verbosity info \
     --log vm_automation.log \
+    --report 1 \
     --ui gui \
     --login user \
     --password 12345678 \
     --remote_folder desktop \
-    --uac_fix 1 \
     --uac_parent 'C:\\Windows\\Explorer.exe' \
     --network keep \
+    --record C:\\video.webm \
     --resolution '1920 1080 32' \
     --pre 'C:\start.cmd' \
     --post 'C:\stop.cmd'
@@ -49,13 +49,14 @@ python demo_cli.py \
 * You must have Windows as the guest OS with autologin configured (or have a snapshot with a user logged in).
 * You must have VirtualBox guest additions installed.
 * It is strongly recommended to have live snapshots to restore to (otherwise it will be *much* slower).
-* Guest disk encryption is *not* supported (at least for now. VBoxManage limitation).
+* VM disk encryption is *not* supported (VBoxManage limitation).
 
 # TODO (version 1.0):
 * Code optimization and fixes.
 * Better tests coverage.
 
 # TODO (version 2.0):
+* Use VirtualBox API.
 * Distribute workload to multiple physical hosts.
 * Implement web interface.
 * Add option to use pre-running VMs.
@@ -63,8 +64,16 @@ python demo_cli.py \
 * Vagrant integration (maybe).
 * VMware support (maybe).
 * Code optimization and fixes.
+* Better tests coverage.
 
 # Changelog
+Version 0.9:
+* Added option to generate html report ('--report'). Result (including screenshots) will be saved under ./reports/<file_hash> directory.
+* Added option to record video from guest VM ('--record output.webm').
+* uac_parent is now applied to both pre_exec and post_exec commands too.
+* Removed '--info' and '--uac_fix' arguments. Both options are enabled from now on.
+* Added alias '--user' for '--login' option.
+
 Version 0.8.2:
 * Added vm_backup(vm) function. Takes live snapshot with name in 'backup_YYYY_MM_DD_HH_MM_SS' format.
 
@@ -157,5 +166,4 @@ Version 0.1:
 # Donations
 You can support further development with a donation (Thanks!).
 
-<a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=XQABQMPTCN388&source=url" target="_blank"><img src="https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif"></img></a>
-
+BTC: bc1qstm95hfx26sf89h62xt804cfzg48z5qxe6cff63ff3s5d2f8f8nq3jf3u4

--- a/demo_cli.py
+++ b/demo_cli.py
@@ -5,7 +5,7 @@ import threading
 import time
 import os
 
-script_version = '0.8.2'
+script_version = '0.9'
 
 try:
     import support_functions
@@ -20,7 +20,7 @@ parser = argparse.ArgumentParser(prog='vm-automation')
 required_options = parser.add_argument_group('Required options')
 required_options.add_argument('file', type=str, nargs='+', help='Path to file')
 required_options.add_argument('--vms', '-v', type=str, nargs='*', required=True,
-                   help='Space-separated list of VMs to use')
+                              help='Space-separated list of VMs to use')
 required_options.add_argument('--snapshots', '-s', type=str, nargs='*', required=True,
                               help='Space-separated list of snapshots to use')
 
@@ -29,33 +29,33 @@ main_options.add_argument('--vboxmanage', default='vboxmanage', type=str, nargs=
                           help='Path to vboxmanage binary (default: %(default)s)')
 main_options.add_argument('--timeout', default=60, type=int, nargs='?',
                           help='Timeout in seconds for both commands and VM (default: %(default)s)')
-main_options.add_argument('--info', default=1, choices=[1, 0], type=int, nargs='?',
-                          help='Show file hash and links to VirusTotal and Google search (default: %(default)s)')
 main_options.add_argument('--threads', default=2, choices=range(9), type=int, nargs='?',
                           help='Number of concurrent threads to run (0=number of VMs, default: %(default)s)')
 main_options.add_argument('--verbosity', default='info', choices=['debug', 'info', 'error'], type=str, nargs='?',
                           help='Log verbosity level (default: %(default)s)')
 main_options.add_argument('--log', default='console', type=str, nargs='?',
                           help='Path to log file (default: %(default)s)')
+main_options.add_argument('--report', default=0, choices=[0, 1], type=int, nargs='?',
+                          help='Enable/disable saving report as html (default: %(default)s)')
 
 guests_options = parser.add_argument_group('Guests options')
 guests_options.add_argument('--ui', default='gui', choices=['gui', 'headless'], nargs='?',
                             help='Start VMs in GUI or headless mode (default: %(default)s)')
-guests_options.add_argument('--login', default='user', type=str, nargs='?',
+guests_options.add_argument('--login', '--user', default='user', type=str, nargs='?',
                             help='Login for guest OS (default: %(default)s)')
 guests_options.add_argument('--password', default='12345678', type=str, nargs='?',
                             help='Password for guest OS (default: %(default)s)')
 guests_options.add_argument('--remote_folder', default='desktop', choices=['desktop', 'downloads', 'documents', 'temp'],
                             type=str, nargs='?',
                             help='Destination folder in guest OS to place file. (default: %(default)s)')
-guests_options.add_argument('--uac_fix', default=1, choices=[0, 1], type=int,
-                            nargs='?', help='Fix for files with UAC elevation (default: %(default)s)')
 guests_options.add_argument('--uac_parent', default='C:\\Windows\\Explorer.exe', type=str,
                             nargs='?', help='Path for parent app, which will start main file (default: %(default)s)')
 guests_options.add_argument('--network', default='keep', choices=['on', 'off', 'keep'], nargs='?',
                             help='State of guest OS network (default: %(default)s)')
 guests_options.add_argument('--resolution', default='1920 1080 32', type=str, nargs='?',
                             help='Screen resolution for guest OS. Can be set to "random" (default: %(default)s)')
+guests_options.add_argument('--record', default='off', type=str, nargs='?',
+                            help='Record full video of runtime on guest OS (default: %(default)s)')
 guests_options.add_argument('--pre', default=None, type=str, nargs='?',
                             help='Script to run before main file (default: %(default)s)')
 guests_options.add_argument('--post', default=None, type=str, nargs='?',
@@ -71,9 +71,7 @@ threads = args.threads
 timeout = args.timeout
 verbosity = args.verbosity
 log = args.log
-
-# support_functions options
-show_info = args.info
+report = args.report
 
 # vm_functions options
 vm_functions.vboxmanage_path = args.vboxmanage
@@ -86,7 +84,6 @@ vm_post_exec = args.post
 vm_login = args.login
 vm_password = args.password
 remote_folder = args.remote_folder
-uac_fix = args.uac_fix
 uac_parent = args.uac_parent
 vm_network_state = args.network
 vm_resolution = args.resolution
@@ -113,10 +110,11 @@ def show_info():
 
     logging.info(f'VMs: {vms_list}')
     logging.info(f'Snapshots: {snapshots_list}\n')
-    result = support_functions.file_info(filename, show_info)
-    if result != 0:
+    result = support_functions.file_info(filename)
+    if result[0] != 0:
         logging.error('Error while processing file. Exiting.')
         exit(1)
+    return result[1]
 
 
 # Function to take screenshot on guest OS
@@ -124,7 +122,10 @@ def take_screenshot(vm, task_name):
     screenshot_index = 1
     while screenshot_index < 10000:
         screenshot_index_zeros = str(screenshot_index).zfill(4)
-        screenshot_name_num = f'{task_name}_{screenshot_index_zeros}.png'
+        if report:
+            screenshot_name_num = f'reports/{sha256}/{task_name}_{screenshot_index_zeros}.png'
+        else:
+            screenshot_name_num = f'{task_name}_{screenshot_index_zeros}.png'
         if os.path.isfile(screenshot_name_num):
             screenshot_index += 1
         else:
@@ -137,6 +138,9 @@ def main_routine(vm, snapshots_list):
     for snapshot in snapshots_list:
         task_name = f'{vm}_{snapshot}'
         logging.info(f'{task_name}: Task started')
+
+        if report:
+            os.makedirs(f'reports/{sha256}', mode=0o444, exist_ok=True)
 
         # Stop VM, restore snapshot, start VM
         vm_functions.vm_stop(vm, ignore_status_error=1)
@@ -174,7 +178,7 @@ def main_routine(vm, snapshots_list):
 
         # Run pre exec script
         if vm_pre_exec:
-            vm_functions.vm_exec(vm, vm_login, vm_password, vm_pre_exec)
+            vm_functions.vm_exec(vm, vm_login, vm_password, vm_pre_exec, uac_parent=uac_parent)
             take_screenshot(vm, task_name)
         else:
             logging.debug('Pre exec is not set.')
@@ -199,8 +203,7 @@ def main_routine(vm, snapshots_list):
         take_screenshot(vm, task_name)
 
         # Run file
-        result = vm_functions.vm_exec(vm, vm_login, vm_password, remote_file_path, uac_fix=uac_fix,
-                                      uac_parent=uac_parent)
+        result = vm_functions.vm_exec(vm, vm_login, vm_password, remote_file_path, uac_parent=uac_parent)
         if result[0] != 0:
             take_screenshot(vm, task_name)
             vm_functions.vm_stop(vm)
@@ -216,10 +219,14 @@ def main_routine(vm, snapshots_list):
 
         # Run post exec script
         if vm_post_exec:
-            vm_functions.vm_exec(vm, vm_login, vm_password, vm_post_exec)
+            vm_functions.vm_exec(vm, vm_login, vm_password, vm_post_exec, uac_parent=uac_parent)
             take_screenshot(vm, task_name)
         else:
             logging.debug('Post exec is not set.')
+
+        # Save html report as ./reports/<file_hash>/index.html
+        if report:
+            support_functions.html_report(vms_list, snapshots_list, filename, sha256, timeout, vm_network_state)
 
         # Stop VM, restore snapshot
         vm_functions.vm_stop(vm)
@@ -244,7 +251,7 @@ if threads == 0:
 else:
     logging.debug(f'Threads count is set to {threads}')
 
-show_info()
+sha256 = show_info()
 
 # Start threads
 for vm in vms_list:

--- a/support_functions.py
+++ b/support_functions.py
@@ -4,6 +4,7 @@ import os
 import random
 import re
 import string
+import datetime
 
 if __name__ == "__main__":
     print('This script only contains functions and cannot be called directly. See "demo_cli.py" for usage example.')
@@ -23,7 +24,7 @@ def file_hash(file):
 
 
 # Show info about file
-def file_info(file, show_info=True):
+def file_info(file):
     file = ''.join(file)
     logging.info(f'File: "{file}"')
 
@@ -33,12 +34,11 @@ def file_info(file, show_info=True):
         return 1
 
     # Print hash and links
-    if show_info:
-        sha256sum = file_hash(file)
-        logging.info(f'sha256: {sha256sum}')
-        logging.info(f'Search VT: https://www.virustotal.com/gui/file/{sha256sum}/detection')
-        logging.info(f'Search Google: https://www.google.com/search?q={sha256sum}\n')
-    return 0
+    sha256sum = file_hash(file)
+    logging.info(f'sha256: {sha256sum}')
+    logging.info(f'Search VT: https://www.virustotal.com/gui/file/{sha256sum}/detection')
+    logging.info(f'Search Google: https://www.google.com/search?q={sha256sum}\n')
+    return 0, sha256sum
 
 
 def randomize_filename(login, file, destination_folder):
@@ -62,4 +62,68 @@ def randomize_filename(login, file, destination_folder):
     random_filename = destination_folder + random_name + file_extension
     logging.debug(f'Remote file: "{random_filename}"')
     return random_filename
+
+
+def html_report(vms_list, snapshots_list, filename, sha256, timeout, vm_network_state, reports_directory='reports'):
+    # Set options and paths
+    now = datetime.datetime.now()
+    time = now.strftime("%Y-%m-%d %H:%M:%S")
+    destination_dir = reports_directory + '/' + sha256
+    destination_file = destination_dir + '/index.html'
+
+    # Create directory, if it does not exist
+    os.makedirs(destination_dir, mode=0o444, exist_ok=True)
+
+    # Content of html file
+    html_template_header = f'''
+    <!DOCTYPE html>
+    <html>
+    <title>Report</title>
+    <body>
+    <h3>File info:</h3>
+    <table>
+      <tr>
+        <td><b>Filename:</b></td>
+        <td>{filename}</td>
+      </tr>
+      <tr>
+        <td><b>Sha256 hash:</b></td>
+        <td>{sha256}</td>
+      </tr>
+      <tr>    
+        <td><b>Scanned on:</b></td>
+        <td>{time}</td>
+      </tr>
+      <tr>    
+        <td><b>Timeout:</b></td>
+        <td>{timeout} seconds</td>
+      </tr>
+      <tr>    
+        <td><b>Network:</b></td>
+        <td>{vm_network_state}</td>
+      </tr>
+    </table>
+    <br>
+    '''
+
+    html_template_screenshots = ''
+    for vm in vms_list:
+        for snapshot in snapshots_list:
+            html_template_screenshots += f'''<h3>VM:</b> {vm}, <b>Snapshot:</b> {snapshot}<h3>'''
+            screenshots = os.listdir(destination_dir)
+            for screenshot in screenshots:
+                # Check if filename matches task name and have .png extension
+                if re.search(rf'{vm}_{snapshot}_\d+\.png', screenshot):
+                    print(f'{screenshot} matches pattern!')
+                    html_template_screenshots += f'''
+                    <a href="{screenshot}" target=_blank><img src="{screenshot}" width="320" high="240"></img></a>
+                    '''
+                else:
+                    print(f'{screenshot} does not matches pattern!')
+
+    html_template_footer = '</body></html>'
+
+    # Write data to report file
+    file_object = open(destination_file, 'w')
+    file_object.write(html_template_header + html_template_screenshots + html_template_footer)
 

--- a/vm_functions.py
+++ b/vm_functions.py
@@ -278,23 +278,17 @@ def vm_set_resolution(vm, screen_resolution):
     return result[0], result[1], result[2]
 
 
-def vm_exec(vm, username, password, remote_file, uac_fix=1, uac_parent='C:\\Windows\\Explorer.exe'):
+def vm_exec(vm, username, password, remote_file, uac_parent='C:\\Windows\\Explorer.exe'):
     """Execute file/command on guest OS
 
     :param vm: Virtual machine name.
     :param username: Guest OS username (login).
     :param password: Guest OS password.
     :param remote_file: Path to file on guest OS.
-    :param uac_fix: Try to bypass VirtualBox error VERR_PROC_ELEVATION_REQUIRED.
-    :param uac_parent: Parent application used to start main file.
     :return: returncode, stdout, stderr.
     """
-    if uac_fix:
-        logging.info(f'{vm}: Executing file "{remote_file}" with parent "{uac_parent}" on VM "{vm}".')
-        result = vboxmanage(f'guestcontrol {vm} --username {username} --password {password} start {uac_parent} {remote_file}')
-    else:
-        logging.info(f'{vm}: Executing file "{remote_file}" on VM "{vm}".')
-        result = vboxmanage(f'guestcontrol {vm} --username {username} --password {password} start {remote_file}')
+    logging.info(f'{vm}: Executing file "{remote_file}" with parent "{uac_parent}" on VM "{vm}".')
+    result = vboxmanage(f'guestcontrol {vm} --username {username} --password {password} start {uac_parent} {remote_file}')
 
     if result[0] == 0:
         logging.debug('File executed successfully.')
@@ -408,6 +402,15 @@ def vm_screenshot(vm, screenshot_name):
 
 
 def vm_record(vm, filename, screens='all', fps=10, duration=0):
+    '''Start screen recording on VM
+
+    :param vm: Virtual machine name.
+    :param filename: Name of file to save video as.
+    :param screens: Screens to record.
+    :param fps: Frames per second.
+    :param duration: Record duration.
+    :return:
+    '''
     logging.info(f'Recording video as "{filename}" on VM "{vm}".')
     result = vboxmanage(f'controlvm {vm} recording screens {screens}')
     if result[0] != 0:
@@ -431,6 +434,11 @@ def vm_record(vm, filename, screens='all', fps=10, duration=0):
 
 
 def vm_record_stop(vm):
+    '''Stop screen recording on VM
+
+    :param vm: Virtual machine name.
+    :return:
+    '''
     logging.info(f'Stopping recording on VM "{vm}".')
     result = vboxmanage(f'controlvm {vm} recording off')
     if result[0] == 0:


### PR DESCRIPTION
Version 0.9:
* Added option to generate html report ('--report'). Result (including screenshots) will be saved under ./reports/<file_hash> directory.
* Added option to record video from guest VM ('--record output.webm').
* uac_parent is now applied to both pre_exec and post_exec commands too.
* Removed '--info' and '--uac_fix' arguments. Both options are enabled from now on.
* Added alias '--user' for '--login' option.