### PR TITLE
0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,64 @@
 # VirtualBox VM automation in Python
-Python script that can be used to automate testing of software/scripts/etc on VMs (currently only VirtualBox is supported). Based on VBoxManage command-line interface and does not require VirtualBox SDK.
+Python script that can be used to automate dynamic testing of binaries/scripts/documents on VMs (currently only VirtualBox is supported).
+Based on VBoxManage command-line interface and does not require VirtualBox SDK.
 
-Both Windows and Linux are supported as host OS.
+Both Windows and Linux are tested as host OS. May work on other platforms, supported by VirtualBox and Python.
 
 # Downloads
-Stable versions are available in [Releases](https://github.com/Pernat1y/vm-automation/releases)
+Stable versions are available in [Releases](https://github.com/Pernat1y/vm-automation/releases).
 
 # Usage:
-Essential commands (command-line interface):
+Essential commands:
 ```
 python demo_cli.py \
-    putty.exe \
+    file.exe \
     --vms windows10 windows8 windows7 \
-    --snapshots firefox chrome edge
+    --snapshots firefox chrome ie
 ```
 
-All options (command-line interface):
+All options (AKA --help):
 ```
-python demo_cli.py \
-    putty.exe \ 
-    --vms windows10 windows8 windows7 \
-    --snapshots firefox chrome ie \
-    --vboxmanage /usr/bin/vboxmanage \
-    --timeout 60 \
-    --delay 10 \
-    --threads 2 \
-    --verbosity info \
-    --log vm_automation.log \
-    --report 1 \
-    --ui gui \
-    --login user \
-    --password 12345678 \
-    --remote_folder desktop \
-    --uac_parent 'C:\\Windows\\Explorer.exe' \
-    --network keep \
-    --record C:\\video.webm \
-    --resolution '1920 1080 32' \
-    --pre 'C:\start.cmd' \
-    --post 'C:\stop.cmd'
+Required options:
+  file                  Path to file
+  --vms [VMS [VMS ...]], -v [VMS [VMS ...]]
+                        Space-separated list of VMs to use
+  --snapshots [SNAPSHOTS [SNAPSHOTS ...]], -s [SNAPSHOTS [SNAPSHOTS ...]]
+                        Space-separated list of snapshots to use
+
+Main options:
+  --vboxmanage [VBOXMANAGE]
+                        Path to vboxmanage binary (default: vboxmanage)
+  --timeout [TIMEOUT]   Timeout in seconds for both commands and VM (default: 60)
+  --delay [DELAY]       Delay in seconds before/after starting VMs (default: 7)
+  --threads [{0,1,2,3,4,5,6,7,8}]
+                        Number of concurrent threads to run (0=number of VMs, default: 2)
+  --verbosity [{debug,info,error,off}]
+                        Log verbosity level (default: info)
+  --debug               Print all messages. Alias for "--verbosity debug" (default: False)
+  --log [LOG]           Path to log file (default: None) (to console)
+  --report              Generate html report (default: False)
+  --record              Record guest' OS screen (default: False)
+  --pcap                Enable recording of VM's traffic (default: False)
+
+Guests options:
+  --ui [{1,0,gui,headless}]
+                        Start VMs in GUI or headless mode (default: gui)
+  --login [LOGIN], --user [LOGIN]
+                        Login for guest OS (default: user)
+  --password [PASSWORD]
+                        Password for guest OS (default: 12345678)
+  --remote_folder [{desktop,downloads,documents,temp}]
+                        Destination folder in guest OS to place file. (default: desktop)
+  --uac_parent [UAC_PARENT]
+                        Path for parent app, which will start main file (default: C:\Windows\Explorer.exe)
+  --network [{on,off}]  State of network adapter of guest OS (default: None)
+  --resolution [RESOLUTION]
+                        Screen resolution for guest OS. Can be set to "random" (default: None)
+  --mac [MAC]           Set MAC address for guest OS. Can be set to "random" (default: None)
+  --get_file [GET_FILE]
+                        Get specific file from guest OS before stopping VM (default: None)
+  --pre [PRE]           Script to run before main file (default: None)
+  --post [POST]         Script to run after main file (default: None)
 ```
 
 # Host configuration
@@ -53,6 +74,7 @@ python demo_cli.py \
 * VM disk encryption is *not* supported (VBoxManage limitation).
 
 # TODO (version 1.0):
+* Small improvements.
 * Code optimization and fixes.
 * Better tests coverage.
 
@@ -68,6 +90,16 @@ python demo_cli.py \
 * Better tests coverage.
 
 # Changelog
+Version 0.10:
+* Added option to dump all VM's network traffic to the file ('--pcap'). File will be saved as {vm_name}_{snapshot}.pcap.
+* Added option '--get_file' to download file (memory dumps, logs, reports, etc) before stopping VM.
+* Removed option 'keep' for all of the arguments. Omitting argument will do the same.
+* Added function vm_set_mac(vm, mac) and option to change MAC address for VM before start.
+Can be set to specific MAC ('--mac 80AABBCCDDEE'), 'new' for random mac in VirtualBox range or 'random' for random one.
+* Logs levels tweaked to make default output more clean.
+* Added argument '--debug' (alias for '--verbosity debug').
+* Added standalone Windows binary. See releases section for download.
+
 Version 0.9.2:
 * Added option '--delay' to control delay before/after starting VMs. Depends on hardware performance.
 * Added md5 checksum calculation.
@@ -118,7 +150,7 @@ Version 0.7.1:
 Version 0.7:
 * Added option to control number of concurrently running tasks ('--threads 2'). Set to '0' to set to number of VMs.
 * Added option to control log verbosity ('--verbosity debug|info|error').
-* Added parameter ignore_status_error to vm_stop() function. Can be used when trying to stop already stopped VM. Disabled by default.
+* Added parameter ignore_status_error to vm_stop() function. May be used when trying to stop already stopped VM.
 * Added aliases for vm_copyto() and vm_copyfrom() functions - vm_upload() and vm_download().
 * Fixed command line arguments processing.
 * Added unittests for some of the functions ('tests/test.py').
@@ -175,7 +207,12 @@ Version 0.1:
 
 <a href="http://www.youtube.com/watch?feature=player_embedded&v=QnXfmPVbmlo" target="_blank"><img src="http://img.youtube.com/vi/QnXfmPVbmlo/0.jpg" width="320" height="240" border="10" /></a>
 
+# Useful links
+<a href="https://github.com/hfiref0x/VBoxHardenedLoader" target="_blank">VirtualBox Hardened VM detection mitigation loader - VBoxHardenedLoader</a>
+
 # Donations
 You can support further development with a donation (Thanks!).
 
-BTC: bc1qstm95hfx26sf89h62xt804cfzg48z5qxe6cff63ff3s5d2f8f8nq3jf3u4
+BTC (Legacy): 1GDy6seYwiK92XAyoQsSeMf2LMR9pCpkY8
+
+BTC (SegWit bech32): bc1q5wzj6qa3d7vtw9cehftt7gvswr60kgfgeu98z6

--- a/demo_cli.py
+++ b/demo_cli.py
@@ -1,11 +1,10 @@
 import argparse
 import logging
 import os
-import random
 import threading
 import time
 
-script_version = '0.9.2'
+script_version = '0.10'
 
 try:
     import support_functions
@@ -33,12 +32,18 @@ main_options.add_argument('--delay', default=7, type=int, nargs='?',
                           help='Delay in seconds before/after starting VMs (default: %(default)s)')
 main_options.add_argument('--threads', default=2, choices=range(9), type=int, nargs='?',
                           help='Number of concurrent threads to run (0=number of VMs, default: %(default)s)')
-main_options.add_argument('--verbosity', default='info', choices=['debug', 'info', 'error'], type=str, nargs='?',
+main_options.add_argument('--verbosity', default='info', choices=['debug', 'info', 'error', 'off'], type=str, nargs='?',
                           help='Log verbosity level (default: %(default)s)')
-main_options.add_argument('--log', default='console', type=str, nargs='?',
-                          help='Path to log file (default: %(default)s)')
-main_options.add_argument('--report', default=0, choices=[0, 1], type=int, nargs='?',
-                          help='Enable/disable saving report as html (default: %(default)s)')
+main_options.add_argument('--debug', action='store_true',
+                          help='Print all messages. Alias for "--verbosity debug" (default: %(default)s)')
+main_options.add_argument('--log', default=None, type=argparse.FileType('w'), nargs='?',
+                          help='Path to log file (default: %(default)s) (console)')
+main_options.add_argument('--report', action='store_true',
+                          help='Generate html report (default: %(default)s)')
+main_options.add_argument('--record', action='store_true',
+                          help='Record guest\' OS screen (default: %(default)s)')
+main_options.add_argument('--pcap', action='store_true',
+                          help='Enable recording of VM\'s traffic (default: %(default)s)')
 
 guests_options = parser.add_argument_group('Guests options')
 guests_options.add_argument('--ui', default='gui', choices=['1', '0', 'gui', 'headless'], nargs='?',
@@ -52,12 +57,15 @@ guests_options.add_argument('--remote_folder', default='desktop', choices=['desk
                             help='Destination folder in guest OS to place file. (default: %(default)s)')
 guests_options.add_argument('--uac_parent', default='C:\\Windows\\Explorer.exe', type=str,
                             nargs='?', help='Path for parent app, which will start main file (default: %(default)s)')
-guests_options.add_argument('--network', default='keep', choices=['on', 'off', 'keep'], nargs='?',
-                            help='State of guest OS network (default: %(default)s)')
-guests_options.add_argument('--resolution', default='1024 768 32', type=str, nargs='?',
+guests_options.add_argument('--network', default=None, choices=['on', 'off'], nargs='?',
+                            help='State of network adapter of guest OS (default: %(default)s)')
+guests_options.add_argument('--resolution', default=None, type=str, nargs='?',
                             help='Screen resolution for guest OS. Can be set to "random" (default: %(default)s)')
-guests_options.add_argument('--record', default='off', type=str, nargs='?',
-                            help='Record full video of runtime on guest OS (default: %(default)s)')
+guests_options.add_argument('--mac', default=None, type=str, nargs='?',
+                            help='Set MAC address for guest OS. Can be set to "random" (default: %(default)s)')
+guests_options.add_argument('--get_file', default=None, type=str, nargs='?',
+                            help='Get specific file from guest OS before stopping VM (default: %(default)s)')
+
 guests_options.add_argument('--pre', default=None, type=str, nargs='?',
                             help='Script to run before main file (default: %(default)s)')
 guests_options.add_argument('--post', default=None, type=str, nargs='?',
@@ -73,8 +81,11 @@ threads = args.threads
 timeout = args.timeout
 delay = args.delay
 verbosity = args.verbosity
+debug = args.debug
 log = args.log
 report = args.report
+record = args.record
+pcap = args.pcap
 
 # vm_functions options
 vm_functions.vboxmanage_path = args.vboxmanage
@@ -86,14 +97,21 @@ vm_pre_exec = args.pre
 vm_post_exec = args.post
 vm_login = args.login
 vm_password = args.password
+keep_filename = args.keep_filename
 remote_folder = args.remote_folder
 uac_parent = args.uac_parent
 vm_network_state = args.network
 vm_resolution = args.resolution
+vm_mac = args.mac
+vm_get_file = args.get_file
 
+# Some VirtualBox commands require full path to file
+cwd = os.getcwd()
 
 # Logging options
-if log == 'none':
+if debug:
+    verbosity = 'debug'
+if log == 'off':
     logging.disable()
 elif verbosity in ['error', 'info', 'debug']:
     log_levels = {'error': logging.ERROR,
@@ -147,20 +165,29 @@ def main_routine(vm, snapshots_list):
         if report:
             os.makedirs(f'reports/{sha256}', mode=0o444, exist_ok=True)
 
-        # Stop VM, restore snapshot, start VM
+        # Stop VM, restore snapshot. Optionally, change MAC address, enable traffic dump.
         vm_functions.vm_stop(vm, ignore_status_error=1)
         time.sleep(delay / 2)
         result = vm_functions.vm_snapshot_restore(vm, snapshot, ignore_status_error=1)
-        # If we were unable to restore snapshot - continue to the next snapshot/VM
         if result[0] != 0:
+            # If we were unable to restore snapshot - continue to the next snapshot/VM
             logging.error(f'Unable to restore VM "{vm}" to snapshot "{snapshot}". Skipping.')
             vm_functions.vm_stop(vm, ignore_status_error=1)
             continue
+        if vm_mac:
+            vm_functions.vm_set_mac(vm, vm_mac)
+        if pcap:
+            if report:
+                pcap_file = f'{cwd}/reports/{sha256}/{vm}_{snapshot}.pcap'
+            else:
+                pcap_file = f'{cwd}/{vm}_{snapshot}.pcap'
+            vm_functions.vm_pcap(vm, pcap_file)
 
+        # Start VM
         time.sleep(delay / 2)
         result = vm_functions.vm_start(vm, ui)
-        # If we were unable to start VM - continue to the next one
         if result[0] != 0:
+            # If we were unable to start VM - continue to the next one
             logging.error(f'Unable to start VM "{vm}". Skipping.')
             continue
 
@@ -174,12 +201,16 @@ def main_routine(vm, snapshots_list):
             continue
 
         # Set guest resolution
-        if vm_resolution == 'random':
-            resolutions = ['1280 1024 32', '1920 1080 32', '1920 1200 32', '2560 1440 32', '3840 2160 32']
-            random_resolution = random.choice(resolutions)
-            vm_functions.vm_set_resolution(vm, random_resolution)
-        else:
-            vm_functions.vm_set_resolution(vm, vm_resolution)
+        vm_functions.vm_set_resolution(vm, vm_resolution)
+
+        # Start screen recording
+        if record:
+            if report:
+                recording_name = f'{cwd}/reports/{sha256}/{vm}_{snapshot}.webm'
+            else:
+                recording_name = f'{cwd}/{vm}_{snapshot}.webm'
+            recording_name = support_functions.normalize_path(recording_name)
+            vm_functions.vm_record(vm, recording_name)
 
         # Run pre exec script
         if vm_pre_exec:
@@ -233,12 +264,31 @@ def main_routine(vm, snapshots_list):
         else:
             logging.debug('Post exec is not set.')
 
+        # Get file from guest
+        if vm_get_file:
+            # Normalize path and extract file name
+            src_path = support_functions.normalize_path(vm_get_file)
+            src_filename = os.path.basename(src_path)
+            if report:
+                # Place in reports directory
+                dst_file = f'{cwd}/reports/{sha256}/{src_filename}'
+            else:
+                # Place in current dir
+                dst_file = f'{cwd}/{src_filename}'
+            # Download file
+            vm_functions.vm_copyfrom(vm, vm_login, vm_password, src_path, dst_file)
+
+        # Stop recording
+        if record:
+            vm_functions.vm_record_stop(vm)
+
+        # Stop VM
+        vm_functions.vm_stop(vm)
+
         # Save html report as ./reports/<file_hash>/index.html
         if report:
             support_functions.html_report(vm, snapshot, filename, file_size, sha256, md5, timeout, vm_network_state)
 
-        # Stop VM
-        vm_functions.vm_stop(vm)
         logging.info(f'{task_name}: Task finished')
 
 

--- a/demo_cli.py
+++ b/demo_cli.py
@@ -97,7 +97,6 @@ vm_pre_exec = args.pre
 vm_post_exec = args.post
 vm_login = args.login
 vm_password = args.password
-keep_filename = args.keep_filename
 remote_folder = args.remote_folder
 uac_parent = args.uac_parent
 vm_network_state = args.network

--- a/support_functions.py
+++ b/support_functions.py
@@ -7,10 +7,18 @@ import re
 import string
 
 if __name__ == "__main__":
-    print('This script only contains functions and cannot be called directly. See "demo_cli.py" for usage example.')
+    print('This script only contains functions and cannot be called directly. See demo scripts for usage examples.')
     exit(1)
 
 
+# Normalize path (replace '\' and '/' with '\\').
+def normalize_path(path):
+    path.replace('\\', '\\\\')
+    normalized_path = path.replace('/', '\\\\')
+    return normalized_path
+
+
+# Calculate file hashed (sha256 and md5)
 def file_hash(file):
     file_hash_sha256 = hashlib.sha256()
     file_hash_md5 = hashlib.md5()
@@ -26,6 +34,7 @@ def file_hash(file):
     return sha256, md5
 
 
+# Calculate file size (in KB)
 def file_size(file):
     size = os.path.getsize(file)
     size_kb = round(size / 1024)
@@ -54,6 +63,7 @@ def file_info(file):
     return 0, sha256, md5, size
 
 
+# Generate random file name
 def randomize_filename(login, file, destination_folder):
     # File name
     random_name = ''.join(random.choice(string.ascii_letters) for _ in range(random.randint(4, 20)))
@@ -77,6 +87,7 @@ def randomize_filename(login, file, destination_folder):
     return random_filename
 
 
+# Generate html report
 def html_report(vm, snapshot, filename, file_size, sha256, md5, timeout, vm_network_state,
                 reports_directory='reports'):
     # Set options and paths


### PR DESCRIPTION
Version 0.10:
* Added option to dump all VM's network traffic to the file ('--pcap'). File will be saved as {vm_name}_{snapshot}.pcap.
* Added option '--get_file' to download file (memory dumps, logs, reports, etc) before stopping VM.
* Removed option 'keep' for all of the arguments. Omitting argument will do the same.
* Added function vm_set_mac(vm, mac) and option to change MAC address for VM before start.
Can be set to specific MAC ('--mac 80AABBCCDDEE'), 'new' for random mac in VirtualBox range or 'random' for random one.
* Logs levels tweaked to make default output more clean.
* Added argument '--debug' (alias for '--verbosity debug').
* Added standalone Windows binary. See releases section for download.